### PR TITLE
Add reusable data structure library

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ You can still run the underlying Yarn commands directly if you prefer.
 
 - **sliding-puzzle** – 15‑puzzle game implemented with Vue 3.
 - **solar-system** – interactive 3D solar system demo built with Three.js.
+- **data-structures-lib** – reusable data structures like `PriorityQueue` and
+  `Graph` with built‑in DFS/BFS helpers.

--- a/apps/data-structures-lib/package.json
+++ b/apps/data-structures-lib/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "data-structures-lib",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "devDependencies": {
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/data-structures-lib/src/Graph.ts
+++ b/apps/data-structures-lib/src/Graph.ts
@@ -1,0 +1,53 @@
+export class Graph<T> {
+  private adj = new Map<T, Set<T>>();
+
+  addNode(value: T): void {
+    if (!this.adj.has(value)) {
+      this.adj.set(value, new Set());
+    }
+  }
+
+  addEdge(from: T, to: T): void {
+    this.addNode(from);
+    this.addNode(to);
+    this.adj.get(from)!.add(to);
+  }
+
+  neighbors(node: T): T[] {
+    return Array.from(this.adj.get(node) || []);
+  }
+
+  bfs(start: T, visit: (node: T) => void): void {
+    const visited = new Set<T>();
+    const queue: T[] = [start];
+    visited.add(start);
+    while (queue.length) {
+      const node = queue.shift()!;
+      visit(node);
+      for (const neighbor of this.neighbors(node)) {
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          queue.push(neighbor);
+        }
+      }
+    }
+  }
+
+  dfs(start: T, visit: (node: T) => void): void {
+    const visited = new Set<T>();
+    const stack: T[] = [start];
+    while (stack.length) {
+      const node = stack.pop()!;
+      if (visited.has(node)) continue;
+      visited.add(node);
+      visit(node);
+      const neighbors = this.neighbors(node);
+      for (let i = neighbors.length - 1; i >= 0; i--) {
+        const neighbor = neighbors[i];
+        if (!visited.has(neighbor)) {
+          stack.push(neighbor);
+        }
+      }
+    }
+  }
+}

--- a/apps/data-structures-lib/src/PriorityQueue.ts
+++ b/apps/data-structures-lib/src/PriorityQueue.ts
@@ -1,0 +1,68 @@
+export type Comparator<T> = (a: T, b: T) => number;
+
+export class PriorityQueue<T> {
+  private heap: T[] = [];
+
+  constructor(private compare: Comparator<T> = (a, b) => (a < b ? -1 : a > b ? 1 : 0)) {}
+
+  size(): number {
+    return this.heap.length;
+  }
+
+  isEmpty(): boolean {
+    return this.heap.length === 0;
+  }
+
+  peek(): T | undefined {
+    return this.heap[0];
+  }
+
+  push(value: T): void {
+    this.heap.push(value);
+    this.bubbleUp(this.heap.length - 1);
+  }
+
+  pop(): T | undefined {
+    if (this.heap.length === 0) return undefined;
+    const top = this.heap[0];
+    const end = this.heap.pop()!;
+    if (this.heap.length > 0) {
+      this.heap[0] = end;
+      this.bubbleDown(0);
+    }
+    return top;
+  }
+
+  private bubbleUp(index: number): void {
+    const element = this.heap[index];
+    while (index > 0) {
+      const parentIndex = Math.floor((index - 1) / 2);
+      const parent = this.heap[parentIndex];
+      if (this.compare(element, parent) >= 0) break;
+      this.heap[parentIndex] = element;
+      this.heap[index] = parent;
+      index = parentIndex;
+    }
+  }
+
+  private bubbleDown(index: number): void {
+    const length = this.heap.length;
+    const element = this.heap[index];
+    while (true) {
+      let leftIndex = 2 * index + 1;
+      let rightIndex = 2 * index + 2;
+      let swap = index;
+
+      if (leftIndex < length && this.compare(this.heap[leftIndex], this.heap[swap]) < 0) {
+        swap = leftIndex;
+      }
+      if (rightIndex < length && this.compare(this.heap[rightIndex], this.heap[swap]) < 0) {
+        swap = rightIndex;
+      }
+      if (swap === index) break;
+      this.heap[index] = this.heap[swap];
+      this.heap[swap] = element;
+      index = swap;
+    }
+  }
+}

--- a/apps/data-structures-lib/src/index.ts
+++ b/apps/data-structures-lib/src/index.ts
@@ -1,0 +1,3 @@
+export * from './PriorityQueue';
+export * from './Graph';
+export * from './utils';

--- a/apps/data-structures-lib/src/utils.ts
+++ b/apps/data-structures-lib/src/utils.ts
@@ -1,0 +1,16 @@
+export function range(start: number, end: number): number[] {
+  const result: number[] = [];
+  for (let i = start; i < end; i++) {
+    result.push(i);
+  }
+  return result;
+}
+
+export function zip<A, B>(a: A[], b: B[]): Array<[A, B]> {
+  const length = Math.min(a.length, b.length);
+  const result: Array<[A, B]> = [];
+  for (let i = 0; i < length; i++) {
+    result.push([a[i], b[i]]);
+  }
+  return result;
+}

--- a/apps/data-structures-lib/tsconfig.json
+++ b/apps/data-structures-lib/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2023"],
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,6 +732,14 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-structures-lib@workspace:apps/data-structures-lib":
+  version: 0.0.0-use.local
+  resolution: "data-structures-lib@workspace:apps/data-structures-lib"
+  dependencies:
+    typescript: "npm:~5.8.3"
+  languageName: unknown
+  linkType: soft
+
 "de-indent@npm:^1.0.2":
   version: 1.0.2
   resolution: "de-indent@npm:1.0.2"


### PR DESCRIPTION
## Summary
- create a new `data-structures-lib` workspace
- implement `PriorityQueue` and `Graph` with DFS/BFS helpers
- add small utility helpers
- document the new package in README

## Testing
- `yarn workspace data-structures-lib tsc --listEmittedFiles`

------
https://chatgpt.com/codex/tasks/task_e_68483d3e8a348333b848a4d6d035bd21