### PR TITLE
Add motion playground app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup sliding-puzzle solar-system
+.PHONY: setup sliding-puzzle solar-system motion-playground
 
 setup:
 	@yarn install
@@ -7,4 +7,7 @@ sliding-puzzle:
 	@yarn workspace sliding-puzzle dev
 
 solar-system:
-	@yarn workspace solar-system dev
+        @yarn workspace solar-system dev
+
+motion-playground:
+        @yarn workspace motion-playground dev

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ make sliding-puzzle
 
 # run the solar system demo
 make solar-system
+
+# run the motion playground
+make motion-playground
 ```
 
 You can still run the underlying Yarn commands directly if you prefer.
@@ -25,3 +28,4 @@ You can still run the underlying Yarn commands directly if you prefer.
 - **solar-system** – interactive 3D solar system demo built with Three.js.
 - **data-structures-lib** – reusable data structures like `PriorityQueue` and
   `Graph` with built‑in DFS/BFS helpers.
+- **motion-playground** – sample animations using the `motion-v` library.

--- a/apps/motion-playground/README.md
+++ b/apps/motion-playground/README.md
@@ -1,0 +1,13 @@
+# Motion Playground
+
+A small Vue 3 playground showcasing animations using [motion-v](https://github.com/motiondivision/motion-vue).
+The app demonstrates basic usage of the `motion` component with interactive examples.
+
+## Development
+
+```bash
+# from repo root
+yarn install
+cd apps/motion-playground
+yarn dev
+```

--- a/apps/motion-playground/index.html
+++ b/apps/motion-playground/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Motion Playground</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/motion-playground/package.json
+++ b/apps/motion-playground/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "motion-playground",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "motion-v": "^1.2.1",
+    "vue": "^3.5.13"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.3",
+    "@vue/tsconfig": "^0.7.0",
+    "typescript": "~5.8.3",
+    "vite": "^6.3.5",
+    "vue-tsc": "^2.2.8"
+  }
+}

--- a/apps/motion-playground/src/App.vue
+++ b/apps/motion-playground/src/App.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import BasicExample from './components/BasicExample.vue'
+import HoverExample from './components/HoverExample.vue'
+import DragExample from './components/DragExample.vue'
+</script>
+
+<template>
+  <h1>Motion Playground</h1>
+  <BasicExample />
+  <HoverExample />
+  <DragExample />
+</template>
+
+<style scoped>
+h1 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+</style>

--- a/apps/motion-playground/src/components/BasicExample.vue
+++ b/apps/motion-playground/src/components/BasicExample.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { motion } from 'motion-v'
+
+const toggle = ref(false)
+</script>
+
+<template>
+  <div class="example">
+    <button @click="toggle = !toggle">Toggle Move</button>
+    <motion.div
+      class="box"
+      :initial="{ x: 0 }"
+      :animate="{ x: toggle ? 150 : 0 }"
+      :transition="{ type: 'spring' }"
+    />
+  </div>
+</template>
+
+<style scoped>
+.example {
+  margin-bottom: 2rem;
+}
+.box {
+  width: 60px;
+  height: 60px;
+  background: #42b883;
+  margin-top: 1rem;
+}
+</style>

--- a/apps/motion-playground/src/components/DragExample.vue
+++ b/apps/motion-playground/src/components/DragExample.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { motion } from 'motion-v'
+</script>
+
+<template>
+  <motion.div
+    class="draggable"
+    drag
+    :dragConstraints="{ left: -100, right: 100, top: -50, bottom: 50 }"
+  />
+</template>
+
+<style scoped>
+.draggable {
+  width: 80px;
+  height: 80px;
+  background: #ff4757;
+  margin: 2rem auto;
+}
+</style>

--- a/apps/motion-playground/src/components/HoverExample.vue
+++ b/apps/motion-playground/src/components/HoverExample.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { motion } from 'motion-v'
+</script>
+
+<template>
+  <motion.button
+    class="fancy"
+    :initial="{ scale: 1 }"
+    :while-hover="{ scale: 1.2 }"
+    :transition="{ duration: 0.3 }"
+  >
+    Hover me
+  </motion.button>
+</template>
+
+<style scoped>
+.fancy {
+  padding: 0.6em 1.2em;
+  font-size: 1rem;
+  border-radius: 8px;
+  border: none;
+  background: #646cff;
+  color: white;
+  cursor: pointer;
+}
+</style>

--- a/apps/motion-playground/src/main.ts
+++ b/apps/motion-playground/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import './style.css'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/apps/motion-playground/src/style.css
+++ b/apps/motion-playground/src/style.css
@@ -1,0 +1,79 @@
+:root {
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+
+  color-scheme: light dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  font-weight: 500;
+  color: #646cff;
+  text-decoration: inherit;
+}
+a:hover {
+  color: #535bf2;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  place-items: center;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+h1 {
+  font-size: 3.2em;
+  line-height: 1.1;
+}
+
+button {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: #1a1a1a;
+  cursor: pointer;
+  transition: border-color 0.25s;
+}
+button:hover {
+  border-color: #646cff;
+}
+button:focus,
+button:focus-visible {
+  outline: 4px auto -webkit-focus-ring-color;
+}
+
+.card {
+  padding: 2em;
+}
+
+#app {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #ffffff;
+  }
+  a:hover {
+    color: #747bff;
+  }
+  button {
+    background-color: #f9f9f9;
+  }
+}

--- a/apps/motion-playground/src/vite-env.d.ts
+++ b/apps/motion-playground/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/motion-playground/tsconfig.app.json
+++ b/apps/motion-playground/tsconfig.app.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+}

--- a/apps/motion-playground/tsconfig.json
+++ b/apps/motion-playground/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/apps/motion-playground/tsconfig.node.json
+++ b/apps/motion-playground/tsconfig.node.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/motion-playground/vite.config.ts
+++ b/apps/motion-playground/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [vue()],
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -421,6 +421,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/web-bluetooth@npm:^0.0.20":
+  version: 0.0.20
+  resolution: "@types/web-bluetooth@npm:0.0.20"
+  checksum: 10c0/3a49bd9396506af8f1b047db087aeeea9fe4301b7fad4fe06ae0f6e00d331138caae878fd09e6410658b70b4aaf10e4b191c41c1a5ff72211fe58da290c7d003
+  languageName: node
+  linkType: hard
+
 "@vitejs/plugin-vue@npm:^5.2.3":
   version: 5.2.4
   resolution: "@vitejs/plugin-vue@npm:5.2.4"
@@ -601,6 +608,34 @@ __metadata:
     vue:
       optional: true
   checksum: 10c0/5b36db5ee9e14b47e516164a21ebbf24e558042a16162a69291fe3dc0dcdf598bc0d9dada1b1008d95afab97a22396e8579e4f0df141a015ffa0837bf6ccbf2f
+  languageName: node
+  linkType: hard
+
+"@vueuse/core@npm:^10.0.0":
+  version: 10.11.1
+  resolution: "@vueuse/core@npm:10.11.1"
+  dependencies:
+    "@types/web-bluetooth": "npm:^0.0.20"
+    "@vueuse/metadata": "npm:10.11.1"
+    "@vueuse/shared": "npm:10.11.1"
+    vue-demi: "npm:>=0.14.8"
+  checksum: 10c0/6a974c1510ce84e652e3d180a4f4373e37e59a5ec025a7a8cec7f144a4ccff25dbdd82e3143ffb057323f467a1076b39da30953981e822c4bd41a7841121afee
+  languageName: node
+  linkType: hard
+
+"@vueuse/metadata@npm:10.11.1":
+  version: 10.11.1
+  resolution: "@vueuse/metadata@npm:10.11.1"
+  checksum: 10c0/c252056aa7e7bd5d207791a2e3b415dcb81fef5b24bfe18cefdec026ae9b7e5a5813100d2e55262fc66feafe15ccdc11a69351d724d848fafe4b3b052e559283
+  languageName: node
+  linkType: hard
+
+"@vueuse/shared@npm:10.11.1":
+  version: 10.11.1
+  resolution: "@vueuse/shared@npm:10.11.1"
+  dependencies:
+    vue-demi: "npm:>=0.14.8"
+  checksum: 10c0/22c4f04be8fdb5e95535cf20f13956fc1f3707540f3730282905e6f9b24f314ada28292e82f4401d88b2c1fcf7fc7203011260958f517abc2b756779243147e3
   languageName: node
   linkType: hard
 
@@ -932,6 +967,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"framer-motion@npm:12.16.0":
+  version: 12.16.0
+  resolution: "framer-motion@npm:12.16.0"
+  dependencies:
+    motion-dom: "npm:^12.16.0"
+    motion-utils: "npm:^12.12.1"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@emotion/is-prop-valid": "*"
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10c0/df8d61553d0aebb2f679620a9c70e90e82b4245fbbd3333d779399b555e6344eb72c453c2483071a9b2c6fd1f8ba680e211b494468d69c9c060a344e0d6d8893
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^3.0.0":
   version: 3.0.3
   resolution: "fs-minipass@npm:3.0.3"
@@ -995,6 +1052,13 @@ __metadata:
   bin:
     he: bin/he
   checksum: 10c0/a27d478befe3c8192f006cdd0639a66798979dfa6e2125c6ac582a19a5ebfec62ad83e8382e6036170d873f46e4536a7e795bf8b95bf7c247f4cc0825ccc8c17
+  languageName: node
+  linkType: hard
+
+"hey-listen@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "hey-listen@npm:1.0.8"
+  checksum: 10c0/38db3028b4756f3d536c0f6a92da53bad577ab649b06dddfd0a4d953f9a46bbc6a7f693c8c5b466a538d6d23dbc469260c848427f0de14198a2bbecbac37b39e
   languageName: node
   linkType: hard
 
@@ -1218,6 +1282,49 @@ __metadata:
   bin:
     mkdirp: dist/cjs/src/bin.js
   checksum: 10c0/9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
+  languageName: node
+  linkType: hard
+
+"motion-dom@npm:^12.16.0":
+  version: 12.17.3
+  resolution: "motion-dom@npm:12.17.3"
+  dependencies:
+    motion-utils: "npm:^12.12.1"
+  checksum: 10c0/6892f070e07fdd4f6d97c347e479a1f706a6ad678f86818ce36d35a89dc79a0cc45804bd5758b95612893f48c8b6353f0cee2a25340b2cde789b8ad323aa592e
+  languageName: node
+  linkType: hard
+
+"motion-playground@workspace:apps/motion-playground":
+  version: 0.0.0-use.local
+  resolution: "motion-playground@workspace:apps/motion-playground"
+  dependencies:
+    "@vitejs/plugin-vue": "npm:^5.2.3"
+    "@vue/tsconfig": "npm:^0.7.0"
+    motion-v: "npm:^1.2.1"
+    typescript: "npm:~5.8.3"
+    vite: "npm:^6.3.5"
+    vue: "npm:^3.5.13"
+    vue-tsc: "npm:^2.2.8"
+  languageName: unknown
+  linkType: soft
+
+"motion-utils@npm:^12.12.1":
+  version: 12.12.1
+  resolution: "motion-utils@npm:12.12.1"
+  checksum: 10c0/880a174769d1be42b46cfb34af81b4a629c068d30d5cf7e07d249fbf2f5121d577482d3ea5bdc1db549c0288733e1e987efecb195fae350995270651559c6697
+  languageName: node
+  linkType: hard
+
+"motion-v@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "motion-v@npm:1.2.1"
+  dependencies:
+    "@vueuse/core": "npm:^10.0.0"
+    framer-motion: "npm:12.16.0"
+    hey-listen: "npm:^1.0.8"
+  peerDependencies:
+    vue: ">=3.0.0"
+  checksum: 10c0/6a5557097d018fdfff734ba1d18a8a42a95003e25c8e7ef5d7ce4e5d5d4cc4969cd3483d15df33de9ca274ea2bad539ad0b45c32d1d230bb7d5af4124e36e0e5
   languageName: node
   linkType: hard
 
@@ -1632,6 +1739,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.4.0":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
 "typescript@npm:~5.8.3":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
@@ -1729,6 +1843,22 @@ __metadata:
   version: 3.1.0
   resolution: "vscode-uri@npm:3.1.0"
   checksum: 10c0/5f6c9c10fd9b1664d71fab4e9fbbae6be93c7f75bb3a1d9d74399a88ab8649e99691223fd7cef4644376cac6e94fa2c086d802521b9a8e31c5af3e60f0f35624
+  languageName: node
+  linkType: hard
+
+"vue-demi@npm:>=0.14.8":
+  version: 0.14.10
+  resolution: "vue-demi@npm:0.14.10"
+  peerDependencies:
+    "@vue/composition-api": ^1.0.0-rc.1
+    vue: ^3.0.0-0 || ^2.6.0
+  peerDependenciesMeta:
+    "@vue/composition-api":
+      optional: true
+  bin:
+    vue-demi-fix: bin/vue-demi-fix.js
+    vue-demi-switch: bin/vue-demi-switch.js
+  checksum: 10c0/a9ed8712fa36d01bc13c39757f95f30cebf42d557b99e94bff86d8660c81f2911b41220f7affc023d1ffcc19e13999e4a83019991e264787cca2c616e83aea48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add a new Vue app `motion-playground` showcasing motion-v animations
- demonstrate basic, hover, and drag examples
- document how to run the app and update Makefile
- list the new app in the repository README

## Testing
- `yarn workspace motion-playground build`


------
https://chatgpt.com/codex/tasks/task_e_684aead2f4b8833382c54704be99c768