### PR TITLE
feat: add graphql demo app

### DIFF
--- a/apps/graphql-demo/README.md
+++ b/apps/graphql-demo/README.md
@@ -1,0 +1,9 @@
+# GraphQL Demo
+
+This package demonstrates a simple GraphQL server with a Vue front-end.
+
+## Available Scripts
+
+- `npm start` – run the GraphQL server on port 4000
+- `npm run dev` – start the Vite dev server for the Vue front-end
+- `npm run build` – build the front-end assets

--- a/apps/graphql-demo/index.html
+++ b/apps/graphql-demo/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GraphQL Vue Demo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/apps/graphql-demo/package.json
+++ b/apps/graphql-demo/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "graphql-demo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "start": "node server.js",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "express-graphql": "^0.12.0",
+    "graphql": "^15.8.0",
+    "vue": "^3.5.13"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.2.3",
+    "vite": "^6.3.5"
+  }
+}

--- a/apps/graphql-demo/server.js
+++ b/apps/graphql-demo/server.js
@@ -1,0 +1,31 @@
+import express from 'express';
+import cors from 'cors';
+import { graphqlHTTP } from 'express-graphql';
+import { buildSchema } from 'graphql';
+
+const schema = buildSchema(`
+  type Query {
+    hello: String
+    randomNumber: Float!
+    greet(name: String!): String!
+  }
+`);
+
+const root = {
+  hello: () => 'Hello GraphQL!',
+  randomNumber: () => Math.random(),
+  greet: ({ name }) => `Hello, ${name}!`
+};
+
+const app = express();
+app.use(cors());
+app.use('/graphql', graphqlHTTP({
+  schema,
+  rootValue: root,
+  graphiql: true
+}));
+
+const port = 4000;
+app.listen(port, () => {
+  console.log(`GraphQL server running at http://localhost:${port}/graphql`);
+});

--- a/apps/graphql-demo/src/main.js
+++ b/apps/graphql-demo/src/main.js
@@ -1,0 +1,38 @@
+import { createApp, ref, onMounted } from 'vue';
+
+const App = {
+  setup() {
+    const message = ref('');
+    const randomNumber = ref(null);
+
+    const fetchData = async () => {
+      const query = `
+        query {
+          hello
+          randomNumber
+        }
+      `;
+      const response = await fetch('http://localhost:4000/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query })
+      });
+      const { data } = await response.json();
+      message.value = data.hello;
+      randomNumber.value = data.randomNumber;
+    };
+
+    onMounted(fetchData);
+
+    return { message, randomNumber, fetchData };
+  },
+  template: `
+    <div>
+      <h1>{{ message }}</h1>
+      <p>Random number: {{ randomNumber }}</p>
+      <button @click="fetchData">Refresh</button>
+    </div>
+  `
+};
+
+createApp(App).mount('#app');

--- a/apps/graphql-demo/vite.config.js
+++ b/apps/graphql-demo/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()]
+});


### PR DESCRIPTION
## Summary
- add GraphQL demo package with Express backend and Vue frontend

## Testing
- `npm run build -w apps/graphql-demo`
- `npm test -w apps/graphql-demo`


------
https://chatgpt.com/codex/tasks/task_e_688e0b421f74833391e143d3ac1622c0